### PR TITLE
Add screenshots to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Rancid Tomatillos
 
-This is an application to display movie posters and then access movie details through an API. The user can access a list of movie posters, select any one of them, & be provided information about that specific film including its rating, description, release year, tagline, running time, and genre(s).
+<img width="1417" alt="Screen Shot 2021-09-06 at 5 24 11 PM" src="https://user-images.githubusercontent.com/22990386/132265533-a180eb44-a65d-4a13-984e-8b74b0e3121c.png">
+
+This is an application to display movie posters and then access movie details through an API. The user can access a list of movie posters, select any one of them, & be provided information about that specific film, including its rating, description, release year, tagline, running time, and genre(s).
 
 The application is deployed and can be [accessed online here](https://rottentomatillos.surge.sh/).
 
 ## Motivation and rubric
 
-This project was a paired project for Turing School of Software & Design during Module 3.
+This project was a paired project for Turing School of Software & Design during module 3.
 
 [The project rubric is linked here.](https://frontend.turing.edu/projects/module-3/rancid-tomatillos-v3.html)
 
@@ -28,7 +30,7 @@ Big successes were setting up React components, application foundations, & imple
 
 ### Middle of project
 
-A challenge was setting up Router especially with match and the need to convert our Movie functional component into a class component.
+A challenge was setting up Router, especially with match and the need to convert our Movie functional component into a class component.
 
 A success was setting up stubbing of api calls in Cypress.
 
@@ -60,7 +62,17 @@ After returning to the poster page, they can use the forward button on their bro
 
 Each page has a unique URL that can be bookmarked and/or manually typed in the address bar.
 
-## GIF
+## Screenshots
+
+### Movie Posters Page
+<img width="1417" alt="Screen Shot 2021-09-06 at 5 24 25 PM" src="https://user-images.githubusercontent.com/22990386/132265588-029bab0d-d06f-435b-b504-e67d3ab89abe.png">
+
+### Movie Details Page
+<img width="1417" alt="Screen Shot 2021-09-06 at 5 24 44 PM" src="https://user-images.githubusercontent.com/22990386/132265599-73f5f0ee-0558-4522-922c-e428af0cddf6.png">
+
+### 404 Error Page
+<img width="1431" alt="Screen Shot 2021-09-06 at 5 25 02 PM" src="https://user-images.githubusercontent.com/22990386/132265602-2b72c931-27b3-40a8-bb42-e2c7006b3c43.png">
+505 Page has same format with different text.
 
 ## Future additions
 


### PR DESCRIPTION
Gifs would not upload from local and would always be above 10mb Github limit so we used screenshots

# Thank you for pushing your code!

## What was implemented?
- Added screenshots

## Were there any issues that arose?
- We tried to add a GIF for 1.5hrs
- Gifcap had a visual bug and always produced file sizes above 10mb
- Locally Haley could not upload any changes
- Locally my gif would not show up

## Is there anything that you need from your teammate?
- NA

## Any other comments, questions, or concerns?
- Someone needs to make a goo screen capture gif maker

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- [ ] open index.html
- [ ] console.log()
- [ ] dev tools

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
